### PR TITLE
feat: Initial isolation of core scoring and NLP setup (Part 1)

### DIFF
--- a/lib/db/jobFeatures.ts
+++ b/lib/db/jobFeatures.ts
@@ -1,3 +1,17 @@
-export const upsertJobFeatures = async (jobId: string, features: any) => {
-  throw new Error("upsertJobFeatures not yet implemented");
+// lib/db/jobFeatures.ts
+
+// Upsert job features to the database 
+
+
+// fields in jobFeatures table
+export type dbJobFeatures = {
+  //job_id: string; // commented out until persistance layer 
+  time_type: string | null;
+  salary_min: number | null;
+  salary_mid: number | null;
+  salary_max: number | null;
+  currency: string | null;
+  department: string | null;
+  salary_source: "metadata" | "text"  | null;
 };
+

--- a/lib/nlp/client.ts
+++ b/lib/nlp/client.ts
@@ -1,0 +1,196 @@
+// lib/nlp/client.ts
+
+// Take a unified AdapterJob (from any source: Greenhouse or generic web), extract reliable structured fields using deterministic rules first, 
+// then LLM for the fuzzy stuff, and return a single merged object ready for DB insertion/scoring.
+
+import OpenAI from "openai";
+import { z } from "zod";
+import type { AdapterJob } from "../adapters/types";
+import { dbJobFeatures } from "../db/jobFeatures";
+import { extractGhFeaturesFromMetadata, extractSalaryFromText, htmlToPlainText, finalizeSalary } from "../normalizers/greenhouse";
+
+// ---- OpenAI client ----
+const apiKey = process.env.OPENAI_API_KEY;
+if (!apiKey) throw new Error("OPENAI_API_KEY missing. Put it in .env/.env.local.");
+const client = new OpenAI({ apiKey });
+
+// Types
+type DBFeatures = dbJobFeatures;
+
+// Contains all fields that are fuzzy to extract and that we don't mind the LLM touching 
+const ZJobNLP = z.object({
+  time_type: z.enum(["full-time","part-time","contract"]).nullable(),
+  location: z.string().nullable(),
+  salary_min: z.number().nullable(),
+  salary_max: z.number().nullable(),
+  salary_mid: z.number().nullable(),
+  remote_policy: z.enum(["onsite","hybrid","remote"]).nullable(),
+  seniority: z.enum(["intern","junior","mid","senior","lead","manager"]).nullable(),
+  department: z.string().nullable(),
+  currency: z.string().nullable(),
+  timezone_requirement: z.string().nullable(),
+});
+
+export type JobNLP = z.infer<typeof ZJobNLP>;
+export type Combined = Partial<DBFeatures> & Partial<JobNLP>;
+
+const EmptyNLP: JobNLP = {
+  time_type: null, location: null, salary_min: null, salary_max: null, salary_mid: null,
+  remote_policy: null, seniority: null, currency: null, timezone_requirement: null, department: null
+};
+
+// ---- helpers (adapter-independent) ----
+
+function pickMetadata(job: AdapterJob): unknown {
+  // Find the raw metadata value within the AdapterJob object.
+  return (job as any)?.raw_json?.metadata ?? (job as any)?.metadata ?? null;
+}
+
+export function pickContent(job: AdapterJob): string {
+  // Retrieves the job.content string for raw content
+  return typeof job?.content === "string" ? job.content : "";
+}
+
+function pickLocationName(job: AdapterJob): string | null {
+  if (typeof job?.location === "string" && job.location) return job.location;
+  const name = (job as any)?.raw_json?.location?.name; // use any bc AdapterRawJson type cannot list every possible variable name a vendor might use
+  return typeof name === "string" && name ? name : null;
+}
+
+// ensures the deterministic value always overrides the LLM value if it exists (v !== undefined && v !== null).
+function mergePreferDeterministic<T extends object, U extends object>(det: T, ai: U): T & U {
+  const out: any = { ...ai };
+  for (const [k, v] of Object.entries(det)) {
+    if (v !== undefined && v !== null) out[k] = v; // deterministic wins if defined
+  }
+  return out;
+}
+
+// check the job description text for strong signals regarding the salary compensation period (hourly vs. annual).
+function unitHints(text: string): { hour: boolean; year: boolean } {
+  const hour = /\b(hourly|per\s*hour|\/\s*(?:hr|hour)|\bhr\b)\b/i.test(text);
+  const year =
+    /\b(annual|per\s*(?:year|yr)|\/\s*(?:year|yr)|salary)\b/i.test(text) ||
+    /\$\s*\d{2,3}\s*[kK]\b/.test(text) ||         // $170k, 150k
+    /\$\s*\d{5,}/.test(text);                      // $170000
+  return { hour, year };
+}
+
+
+// ---- Core: analyze an AdapterJob ----
+export async function analyzeAdapterJob(job: AdapterJob): Promise<Combined> {
+    // 1) Start with deterministic features (from GH metadata only if GH)
+    // If this job came from Greenhouse, try to pull the structured fields from their metadata array.
+    let features: Partial<DBFeatures> = {};
+    
+    if (job.ats_provider === "greenhouse") {
+        try {
+        features = extractGhFeaturesFromMetadata(pickMetadata(job));
+        } catch(err) {
+            console.warn("Failed to extract Greenhouse metadata:", err);
+            features = {};
+        }
+    }
+
+    // 2) Convert the adapter’s HTML/content into plain text.
+    const rawText = htmlToPlainText(pickContent(job));
+    const plainText = rawText.slice(0, 20_000);
+
+    const f2 = { ...features }; //shallow copy to keep top features 
+    //If there’s enough text, run heuristics to find salary ranges and set salary_min/max
+    extractSalaryFromText(plainText, f2);
+
+    const { hour} = unitHints(plainText);
+
+    // If numbers are small but no explicit hourly words, delete
+    if (f2.salary_min != null && f2.salary_max != null) {
+    const min = Number(f2.salary_min);
+    const max = Number(f2.salary_max);
+    const tinyRange = max <= 100;
+
+    if (tinyRange && !hour) {
+        delete f2.salary_min;
+        delete f2.salary_max;
+        delete f2.salary_mid;
+        delete f2.salary_source;
+    }
+    }
+    
+
+    features = f2;
+
+    // 3) LLM Schema with fields
+    const schema = {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+        location: { type: ["string","null"] },
+        salary_min: { type: ["number","null"] },
+        salary_max: { type: ["number","null"] },
+        salary_mid: { type: ["number","null"] },
+        remote_policy: { type: ["string","null"], enum: ["onsite","hybrid","remote"] },
+        seniority: { type: ["string","null"], enum: ["intern","junior","mid","senior","lead","manager"] },
+        time_type: { type: ["string","null"], enum: ["full-time","part-time","contract"] },
+        currency: { type: ["string","null"] },
+        department: {type: ["string","null"]},
+        timezone_requirement: { type: ["string","null"] },
+        },
+        required: ["location","salary_max","salary_min","salary_mid","remote_policy","seniority","time_type","currency","timezone_requirement", "department"],
+    } as const;
+    // The schema enforces allowed keys and types; temperature is low for consistency; results are validated (and retried once) 
+    const callOnce = async (): Promise<JobNLP> => {
+        const resp = await client.responses.create({
+        model: "gpt-4o-mini",
+        temperature: 0.2,
+        input: [
+            {
+            role: "system",
+            content:
+                "You are a structured information extractor for job postings. " +
+                "Return ONLY valid JSON that matches the provided JSON Schema. " +
+                "If a value is not explicitly stated, return null. Never invent values. " +
+                "Extract location from content which must be a human-readable geography (city + state/province + country if present)). " +
+                "Currency must be the three-letter ISO 4217 code (e.g., USD, CAD, GBP)." 
+            },
+            { role: "user", content: "Full job text: " + plainText },
+        ],
+        text: {
+            format: { type: "json_schema", name: "job_info", schema, strict: true },
+        },
+        });
+
+    const raw = resp.output_text ?? "{}";
+    const obj = JSON.parse(raw);
+    const parsed = ZJobNLP.safeParse(obj);
+    if (!parsed.success) throw new Error("validation failed");
+    return parsed.data;
+  };
+
+   let aiData: JobNLP;
+   let firstError: unknown; // Store the first error
+    try {
+        aiData = await callOnce();
+    } catch (e) {
+        firstError = e;
+        try {
+            aiData = await callOnce();
+        } catch (e2) {
+            console.error("LLM failed twice:", e, e2);
+            const combinedError = new Error("LLM analysis failed after 2 retries.");
+            (combinedError as any).firstAttemptError = firstError;
+            (combinedError as any).secondAttemptError = e2;
+            throw combinedError; 
+        }
+    }
+
+    // If the LLM didn’t give a location, try to pull a deterministic one from the adapter.
+    aiData.location ??= pickLocationName(job); 
+
+    // Merge features and aiData with a rule that deterministic values are priority if they’re defined.
+    const merged = mergePreferDeterministic(features, aiData);
+
+    // compute salary_mid if we have min/max.
+    finalizeSalary(merged as any); 
+
+    return merged;
+}

--- a/lib/nlp/index.ts
+++ b/lib/nlp/index.ts
@@ -1,0 +1,136 @@
+//lib/nlp/index.ts
+// Extra analysis with NLP
+
+import OpenAI from "openai";
+
+export type skillType = { name: string;};
+
+export type analysis = {
+  skills: skillType[]; // up to 20
+  buzzwords: { hits: string[]; count: number };
+  comp_period_detected: "hour" | "year" | null;
+};
+
+
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+
+const buzzwordList = 
+[ "rockstar",
+  "ninja",
+  "dynamic",
+  "fast-paced",
+  "self-starter",
+  "wear many hats",
+]
+
+export async function analysisWithLLM(
+  {
+    text,                          // cleaned HTML->text, 
+    metadata, 
+    model = "gpt-4o-mini",    
+    temperature = 0.2
+  }: {
+    text: string;
+    // metadata is defined here if you need it (it's passed from scoring/nlp.ts)
+    metadata: { time_type?: string|null; currency?: string|null }; 
+    model?: string;
+    temperature?: number;
+  }
+): Promise<analysis> {
+
+
+  // ---- JSON schema ONLY for insights ----
+  const schema = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      skills: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            name: { type: "string" },
+          },
+          required: ["name"]
+        }
+      },
+      buzzwords: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          hits: { type: "array", items: { type: "string" } },
+          count: { type: "integer" }
+        },
+        required: ["hits","count"]
+      },
+      comp_period_detected: { type: ["string","null"], enum: ["hour","year"] }
+    },
+    required: ["skills","buzzwords","comp_period_detected"]
+  } as const;
+
+  const system = [
+    "You extract scoring-only signals from job postings.",
+    "Use the provided HINTS to guide you, but verify against the text.",
+    "Return ONLY valid JSON matching the schema.",
+    "Guidelines:",
+    "- skills: up to 20 canonical skills (e.g., 'SQL', 'Python', 'AWS', 'Stakeholder management').",
+    "- check for job posting buzzwords that may be red flags: list and count actual occurrences in text (cross-check given hints).",
+    "- comp_period_detected: 'hour' or 'year' if clearly implied; else null."
+  ].join("\n");
+
+    const userPrompt = [
+        "Full job text to analyze:",
+        text,
+        "\n--- HINTS (Do not invent based on these): ---",
+        `Time Type already determined: ${metadata.time_type ?? 'None'}`,
+        `Currency already determined: ${metadata.currency ?? 'None'}`,
+        ];
+
+    if (buzzwordList.length > 0) {
+        userPrompt.push(`\n--- CUSTOM BUZZWORDS ---\nCheck for the following red-flag terms in the JOB TEXT and count their exact occurrences for the 'buzzwords' field: ${buzzwordList.join(', ')}`);
+    }
+
+    const finalUserPrompt = userPrompt.join('\n'); // Rename variable for clarity
+
+    try { 
+        const resp = await client.responses.create({
+        model,
+        temperature,
+        input: [
+        { role: "system", content: system }, { role: "user", content: finalUserPrompt },
+        ],
+        text : {
+            format : {
+                type: 'json_schema',
+                name: 'analysis',
+                schema,
+                strict: true,
+
+            },
+        },
+    });
+    // Safety checks on LLM results
+    const parsed = JSON.parse(resp.output_text ?? "{}");
+
+    if (!Array.isArray(parsed.skills)) parsed.skills = [];
+
+    parsed.skills = parsed.skills
+    .filter((s: any) => typeof s?.name === "string")
+    .map((s: any) => ({ name: String(s.name).slice(0, 64) })) // Maps to { name: string }
+    .slice(0, 20);
+
+    if (!["hour", "year", null].includes(parsed.comp_period_detected)) parsed.comp_period_detected = null;
+
+    return parsed as analysis; // Returns the clean type
+    } catch(error)
+    {
+        console.error("Error during LLM analysis or JSON parsing:", error); 
+        return {
+            skills: [],
+            buzzwords: { hits: [], count: 0 },
+            comp_period_detected: null,
+        }; 
+    }
+}

--- a/lib/normalizers/greenhouse.ts
+++ b/lib/normalizers/greenhouse.ts
@@ -2,14 +2,14 @@
 import { z } from "zod";
 
 export type GHCanon = {
-  time_type?: string;
-  salary_min?: number;
-  salary_mid?: number;
-  salary_max?: number;
-  currency?: string;
-  department?: string;
-  salary_source?: "metadata" | "text";
-  comp_period?: "hour" | "year";
+  time_type?: string | null;
+  salary_min?: number | null;
+  salary_mid?: number | null;
+  salary_max?: number | null;
+  currency?: string | null;
+  department?: string | null;
+  salary_source?: "metadata" | "text" | null;
+  comp_period?: "hour" | "year" | null;
 };
 
 /** Zod guard for GH metadata array (kept permissive). */
@@ -47,12 +47,20 @@ function asMetadataArray(raw: unknown): Array<z.infer<typeof ZGHMetadataItem>> {
   return [];
 }
 
-function finalizeSalary(features: GHCanon) {
+export function finalizeSalary(features: GHCanon) {
   const has = (n: unknown) => typeof n === "number" && Number.isFinite(n);
 
   let min = features.salary_min;
   let mid = features.salary_mid;
   let max = features.salary_max;
+
+    // --- NEW LOGIC ADDED HERE TO CORRECT MISASSIGNED MAX/MID ---
+    // If we have a Min, a Mid, but NO Max, and Mid > Min, Mid is likely the Max.
+    if (has(min) && has(mid) && !has(max) && (mid as number) > (min as number)) {
+        max = mid; 
+        mid = undefined; // Clear midpoint to recalculate later
+        features.salary_mid = undefined;
+    }
 
   // Keep ordering sane if both provided
   if (has(min) && has(max) && (min as number) > (max as number)) {
@@ -122,7 +130,7 @@ export function htmlToPlainText(html: string): string {
  *   - Use only base salary labels (ignore OTE/on-target and any equity/RSU).
  *   - Do not invent a max from a mid.
  *   - If only min exists, leave max unset.
- *   - Heuristic for comp period: <= 300 → "hour", otherwise "year".
+ *   - Heuristic for comp period: <= 300 → "hour", otherwise "year".        
  */
 export function extractGhFeaturesFromMetadata(raw: unknown): GHCanon {
   const features: GHCanon = {};
@@ -178,6 +186,8 @@ export function extractGhFeaturesFromMetadata(raw: unknown): GHCanon {
         setCurrencyAmt("salary_mid", m.value, label);
       }
     }
+
+    
 
     // Time type
     if (name === "Time Type" && typeof m.value === "string") {

--- a/lib/scoring/nlp.ts
+++ b/lib/scoring/nlp.ts
@@ -1,0 +1,35 @@
+// lib/scoring/nlp.ts
+import { analyzeAdapterJob, Combined, pickContent } from "../nlp/client"; 
+import { analysis, analysisWithLLM } from "../nlp/index";           
+import { htmlToPlainText } from "../normalizers/greenhouse";        
+import type { AdapterJob } from "../adapters/types";      
+
+
+export type scoringTypes = {
+    featuresNormalized: Partial<Combined>; 
+    analysis: analysis;                     
+};
+
+export async function analyzeAndScoreJob(jobData: AdapterJob): Promise<scoringTypes> {
+    
+    // This gives us the database fields 
+    const features: Combined = await analyzeAdapterJob(jobData);
+
+    // Re-extract the clean text from the job object for the second LLM call.
+    const html = pickContent(jobData); 
+    const plainText = htmlToPlainText(html)
+
+
+    const analysisResult = await analysisWithLLM({
+        text: plainText,
+        metadata: {
+            time_type: features.time_type ?? null,
+            currency: (features.currency ?? null) as string | null,
+        },
+    });
+
+    return {
+        featuresNormalized: features,
+        analysis: analysisResult,
+    };
+}


### PR DESCRIPTION
Files Contained :

lib/db/jobFeatures.ts
Updated DB schema type to reflect non-optional fields with nullable values (Type | null). This standardizes the final output format. 

lib/normalizers/greenhouse.ts
Tweaked type system (GHCanon) for full compatibility with new  Partial<DBFeatures> and tweaked logic in the finalizeSalary function.

lib/nlp/client.ts
Core feature extraction logic. Implements the layered approach (Metadata → Text → LLM), adds two-retry error handling for LLM calls, and enforces data merging priority.

lib/nlp/index.ts
Secondary scoring analysis. Implements a LLM call to extract skills and buzzwords. 

lib/scoring/nlp.ts
This file acts as the overall workflow that runs the full job analysis: it first extracts the core features (salary, location) and then immediately follows up by getting the scoring insights (skills, buzzwords), packaging everything for the final score.